### PR TITLE
Add cross-platform support for pre/post version script hooks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ sudo: false
 language: node_js
 matrix:
   include:
-    - node_js: 0.10
-    - node_js: 0.11
-    - node_js: 0.12
     - node_js: 4
-    - node_js: 5
     - node_js: 6
+    - node_js: 7
 
 # Mocha sometimes fails (not sure why), so when that happens, try again.
 # If it fails a second time, then the CI build fails.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+# Test against this version of Node.js
+environment:
+  matrix:
+    - nodejs_version: "Stable"
+    - nodejs_version: "LTS"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/bin/bump.js
+++ b/bin/bump.js
@@ -56,6 +56,9 @@ else {
   bumpManifests(manifests, options)
     .then(function() {
       api.grep(manifests, options);
+      manifests.forEach(function (manifest) {
+        api.runNpmScriptIfExists(manifest, 'version');
+      });
     })
     .then(function() {
       api.git(manifests, options);
@@ -120,6 +123,7 @@ function bumpManifest(manifest, defaultBumpType, options) {
         ]
       })
       .then(function(answer) {
+        api.runNpmScriptIfExists(manifest, 'preversion');
         bump(answer.bump);
       });
     }
@@ -133,6 +137,7 @@ function bumpManifest(manifest, defaultBumpType, options) {
             options.prepatch ? 'prepatch' :
             options.prerelease ? 'prerelease' :
             defaultBumpType;
+      api.runNpmScriptIfExists(manifest, 'preversion');
       bump(bumpType);
     }
 

--- a/bin/bump.js
+++ b/bin/bump.js
@@ -98,7 +98,7 @@ function bumpManifests(manifests, options) {
  * @returns {Promise}
  */
 function bumpManifest(manifest, defaultBumpType, options) {
-  return new Promise(function(resolve) {
+  return new Promise(function(resolve, reject) {
     if (options.prompt) {
       // Prompt the user for the type of bump to perform
       var version = api.versionInfo(manifest, options);
@@ -137,7 +137,11 @@ function bumpManifest(manifest, defaultBumpType, options) {
     }
 
     function bump(bumpType) {
-      api.bump(manifest, bumpType, options);
+      try {
+        api.bump(manifest, bumpType, options);
+      } catch(ex) {
+        reject(ex);
+      }
       resolve(bumpType);
     }
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ module.exports = {
   manifests: manifests,
   versionInfo: versionInfo,
   bump: bump,
+  runNpmScriptIfExists: runNpmScriptIfExists,
   grep: grep,
   git: git
 };
@@ -85,9 +86,7 @@ function bump(manifest, type, options) {
   // Save the file
   var usedIndent = indent(fs.readFileSync(pkgPath, 'utf8')).indent || '  ';
 
-  runNpmScriptIfExists(pkg.scripts, 'preversion');
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, usedIndent));
-  runNpmScriptIfExists(pkg.scripts, 'postversion');
 
   console.log('%s Updated %s to %s', logSymbols.success, manifest, current.version);
 }
@@ -95,21 +94,19 @@ function bump(manifest, type, options) {
 /**
  * Takes npm scripts object and if a script exists, runs the script.
  *
- * @param {object} pkgScripts - Scripts section from package.json
+ * @param {string} manifest - The name of the manifest file (e.g. "package.json")
  * @param {string} script - Name of the script ("preversion", "postversion", etc.)
  */
-function runNpmScriptIfExists(pkgScripts, script) {
+function runNpmScriptIfExists(manifest, script) {
+  if (manifest !== 'package.json') {
+    return;
+  }
+  var pkgPath = path.join(cwd, manifest);
+  var pkg = require(pkgPath);
+  var pkgScripts = pkg.scripts;
+
   if (pkgScripts && pkgScripts[script]) {
-    try {
-      exec('npm', ['run', script], {skipCustomErrorLog: true});
-    } catch (ex) {
-      //windows fallback, until https://github.com/libuv/libuv/pull/358 is fixed
-      if (ex.code === 'ENOENT') {
-        exec('npm.cmd', ['run', script]);
-      } else {
-        throw ex;
-      }
-    }
+    exec('npm', ['run', script]);
   }
 }
 
@@ -184,6 +181,10 @@ function git(manifests, options) {
       console.log(logSymbols.success, 'Git tag');
     }
 
+    manifests.forEach(function (manifest) {
+      runNpmScriptIfExists(manifest, 'postversion');
+    });
+
     // Git Push
     if (options.push) {
       exec('git', ['push']);
@@ -206,7 +207,11 @@ function exec(command, args, opts) {
   opts = opts || {};
   var skipCustomErrorLog = opts.skipCustomErrorLog;
   delete opts.skipCustomErrorLog;
-  var result = spawnSync(command, args, opts);
+  //use which to make sure that node spawn can find correct executable, at the moment this is used as
+  //a windows fallback, until https://github.com/libuv/libuv/pull/358 is fixed
+  var which = require('npm-which')(process.cwd());
+  var pathToCommand = which.sync(command);
+  var result = spawnSync(pathToCommand, args, opts);
   if (result.status || result.error) {
     if (!skipCustomErrorLog) {
       console.error(

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,9 +84,33 @@ function bump(manifest, type, options) {
 
   // Save the file
   var usedIndent = indent(fs.readFileSync(pkgPath, 'utf8')).indent || '  ';
+
+  runNpmScriptIfExists(pkg.scripts, 'preversion');
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, usedIndent));
+  runNpmScriptIfExists(pkg.scripts, 'postversion');
 
   console.log('%s Updated %s to %s', logSymbols.success, manifest, current.version);
+}
+
+/**
+ * Takes npm scripts object and if a script exists, runs the script.
+ *
+ * @param {object} pkgScripts - Scripts section from package.json
+ * @param {string} script - Name of the script ("preversion", "postversion", etc.)
+ */
+function runNpmScriptIfExists(pkgScripts, script) {
+  if (pkgScripts && pkgScripts[script]) {
+    try {
+      exec('npm', ['run', script], {skipCustomErrorLog: true});
+    } catch (ex) {
+      //windows fallback, until https://github.com/libuv/libuv/pull/358 is fixed
+      if (ex.code === 'ENOENT') {
+        exec('npm.cmd', ['run', script]);
+      } else {
+        throw ex;
+      }
+    }
+  }
 }
 
 /**
@@ -175,18 +199,27 @@ function git(manifests, options) {
  *
  * @param {string}    command - The command to run
  * @param {string[]}  args - An array of arguments to pass
+ * @param {object} [opts] - Options to pass to spawnSync
+ * @param {boolean} [opts.skipCustomErrorLog] - Use to skip logging the error when using try-catch
  */
-function exec(command, args) {
-  var result = spawnSync(command, args);
-  var output = result.stdout.toString() || result.stderr.toString();
-
+function exec(command, args, opts) {
+  opts = opts || {};
+  var skipCustomErrorLog = opts.skipCustomErrorLog;
+  delete opts.skipCustomErrorLog;
+  var result = spawnSync(command, args, opts);
   if (result.status || result.error) {
-    console.error(
-      chalk.bold.red('Error running command:'),
-      chalk.reset.magenta(command, args.join(' '))
-    );
+    if (!skipCustomErrorLog) {
+      console.error(
+        chalk.bold.red('Error running command:'),
+        chalk.reset.magenta(command, args.join(' '))
+      );
+    }
 
-    var err = new Error(output);
+    var err = result.error;
+    if (!result.error) {
+      var output = result.stdout.toString() || result.stderr.toString();
+      err = new Error(output);
+    }
     err.status = result.status;
     throw err;
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "lint": "jshint . --verbose && jscs . --verbose",
     "build": "npm run lint",
-    "test": "mocha --bail --recursive tests/fixtures tests/specs",
+    "test": "mocha --bail --recursive --timeout 13000 tests/fixtures tests/specs",
     "upgrade": "npm-check -u",
     "bump": "node bin/bump.js --prompt --tag --push --all",
     "release": "npm run upgrade && npm run build && npm test && npm run bump && npm publish",
@@ -42,6 +42,7 @@
     "lodash": "^4.16.4",
     "mocha": "^3.1.1",
     "npm-check": "^5.4.0",
+    "npm-which": "^3.0.1",
     "sinon": "^1.17.6"
   },
   "dependencies": {
@@ -61,5 +62,8 @@
   ],
   "bin": {
     "bump": "bin/bump.js"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }

--- a/tests/fixtures/.tmp/git.cmd
+++ b/tests/fixtures/.tmp/git.cmd
@@ -1,0 +1,7 @@
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe"  "%~dp0\..\bin\git" %*
+) ELSE (
+  @SETLOCAL
+  @SET PATHEXT=%PATHEXT:;.JS;=;%
+  node  "%~dp0\..\bin\git" %*
+)

--- a/tests/fixtures/bin/git.cmd
+++ b/tests/fixtures/bin/git.cmd
@@ -1,0 +1,7 @@
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe"  "%~dp0\git" %*
+) ELSE (
+  @SETLOCAL
+  @SET PATHEXT=%PATHEXT:;.JS;=;%
+  node  "%~dp0\git" %*
+)

--- a/tests/specs/version-hooks.spec.js
+++ b/tests/specs/version-hooks.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var helper = require('../fixtures/helper');
+
+describe('npm version hooks', function() {
+  it('should commit temp file created by version hooks', function() {
+    helper.bump('--major --commit', {
+      version: '1.0.0',
+      scripts: {
+        preversion: 'echo Hi > preversion.txt',
+        version: 'echo Hi > version.txt',
+        postversion: 'echo Hi > postversion.txt'
+      }
+    }, {
+      version: '2.0.0',
+      scripts: {
+        preversion: 'echo Hi > preversion.txt',
+        version: 'echo Hi > version.txt',
+        postversion: 'echo Hi > postversion.txt'
+      }
+    });
+    ['preversion.txt', 'version.txt', 'postversion.txt'].forEach(function (file) {
+      require('chai').expect(
+        fs.existsSync(path.join(__dirname, '../fixtures/.tmp/' + file)) || file + ' to exist'
+      ).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Also fix error reporting for exec function that was failing when result `stdout` and `stderr` are null (for example in case when `ENOENT` error is surfaced). Fixes: https://github.com/BigstickCarpet/version-bump-prompt/issues/2