### PR TITLE
Show the spawned process output when executing a pkgScript

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ function runNpmScriptIfExists (manifest, script) {
   let pkgScripts = pkg.scripts;
 
   if (pkgScripts && pkgScripts[script]) {
-    exec('npm', ['run', script]);
+    exec('npm', ['run', script], { stdio: 'inherit' });
   }
 }
 
@@ -227,8 +227,8 @@ function git (manifests, options) {
  * @param {string}    command - The command to run
  * @param {string[]}  args - An array of arguments to pass
  */
-function exec (command, args) {
-  let result = spawnSync(command, args);
+function exec (command, args, opts) {
+  let result = spawnSync(command, args, opts);
 
   if (result.status || result.error) {
     console.error(


### PR DESCRIPTION
Fixes #26 

I have added the `stdio: inherit` option to the "exec" command used to run pkgScripts