### PR TITLE
add --no-verify switch

### DIFF
--- a/bin/bump.js
+++ b/bin/bump.js
@@ -19,6 +19,7 @@ program
   .option("--prompt", "Prompt for type of bump (patch, minor, major, premajor, prerelase, etc.)")
   .option("--preid <name>", 'The identifier for prerelease versions (default is "beta")')
   .option("--commit [message]", 'Commit changed files to Git (default message is "release vX.X.X")')
+  .option("--no-verify", "Bypasses the pre-commit and commit-msg hooks")
   .option("--tag", "Tag the commit in Git")
   .option("--push", "Push the Git commit")
   .option("--all", "Commit/tag/push ALL pending files, not just the ones changed by bump")

--- a/lib/index.js
+++ b/lib/index.js
@@ -192,6 +192,9 @@ function git (manifests, options) {
 
   // Git Commit
   let commitArgs = ["commit"];
+  if (!options.verify) {
+    commitArgs.push("--no-verify");
+  }
   commitArgs = commitArgs.concat(options.all ? "-a" : manifests);
   let commitMessage = "release v" + newVersion;
   if (options.commitMessage) {

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ Options:
   --prompt              Prompt for type of bump (patch, minor, major, premajor, prerelase, etc.)
   --preid <name>        The identifier for prerelease versions (default is "beta")
   --commit [message]    Commit changed files to Git (default message is "release vX.X.X")
+  --no-verify           Bypasses the pre-commit and commit-msg hooks
   --tag                 Tag the commit in Git
   --push                Push the Git commit
   --all                 Commit/tag/push ALL pending files, not just the ones changed by bump

--- a/test/specs/commit.spec.js
+++ b/test/specs/commit.spec.js
@@ -68,6 +68,25 @@ describe("bump --commit", () => {
     git[0].cmd.should.equal('git commit -a -m "release v1.1.0"');
   });
 
+  it("should commit without running pre-commit hooks", () => {
+    files.create("package.json", { version: "1.0.0" });
+
+    let bump = chaiExec("--minor --commit --all --no-verify");
+
+    bump.stderr.should.be.empty;
+    bump.should.have.exitCode(0);
+
+    bump.should.have.stdout(
+      `${check} Updated package.json to 1.1.0\n` +
+      `${check} Git commit\n`
+    );
+
+    let git = mocks.git();
+    git.length.should.equal(1);
+
+    git[0].cmd.should.equal('git commit --no-verify -a -m "release v1.1.0"');
+  });
+
   it("should commit the manifest files to git with a message", () => {
     files.create("package.json", { version: "1.0.0" });
 


### PR DESCRIPTION
First, thanks for this little module. It works really well for our use cases. I noticed that there was a request for this feature in https://github.com/JS-DevTools/version-bump-prompt/issues/24.

We also had this use case, so I went ahead and implemented it (really small change).